### PR TITLE
#15 Limpar os campos após cadastro de campo obrigatório

### DIFF
--- a/sysarq/src/pages/Fields/Create/CreateBoxAbbreviation.js
+++ b/sysarq/src/pages/Fields/Create/CreateBoxAbbreviation.js
@@ -57,6 +57,16 @@ export default function CreateBoxAbbreviation() {
 		);
 	};
 
+	const onSuccess = () => {
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText("Caixa cadastrada!");
+		setBoxName("");
+		setBoxNumber("");
+		setBoxAbbreviation("");
+		setBoxYear("");
+	}
+
 	const onClick = () => {
 		if (boxNumber === "") {
 			setboxNumberError(true);
@@ -93,9 +103,7 @@ export default function CreateBoxAbbreviation() {
 						{ headers: { Authorization: `JWT ${localStorage.getItem("tk")}` } }
 					)
 					.then(() => {
-						setOpenAlert(true);
-						setSeverityAlert("success");
-						setAlertHelperText("Caixa cadastrada!");
+						onSuccess();
 					})
 					.catch(() => {
 						connectionError();

--- a/sysarq/src/pages/Fields/Create/CreateDocumentSubject.js
+++ b/sysarq/src/pages/Fields/Create/CreateDocumentSubject.js
@@ -72,6 +72,14 @@ export default function CreateDocumentSubject() {
 		},
 	];
 
+	const onSuccess = () => {
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText("Assunto cadastrado!");
+		setTemporality("");
+		setDocumentSubject("");
+	}
+
 	const onClick = () => {
 		if (documentSubject === "") {
 			setdocumentSubjectError(true);
@@ -100,9 +108,7 @@ export default function CreateDocumentSubject() {
 						{ headers: { Authorization: `JWT ${localStorage.getItem("tk")}` } }
 					)
 					.then(() => {
-						setOpenAlert(true);
-						setSeverityAlert("success");
-						setAlertHelperText("Assunto cadastrado!");
+						onSuccess();
 					})
 					.catch(() => {
 						connectionError();

--- a/sysarq/src/pages/Fields/Create/CreateDocumentType.js
+++ b/sysarq/src/pages/Fields/Create/CreateDocumentType.js
@@ -48,6 +48,14 @@ export default function CreateDocumentType() {
 		);
 	};
 
+	const onSuccess = () => {
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText("Tipo cadastrado!");
+		setDocumentName("");
+		setTemporality("");
+	}
+
 	const onClick = () => {
 		if (documentName === "") {
 			setdocumentTypeError(true);
@@ -76,9 +84,7 @@ export default function CreateDocumentType() {
 						{ headers: { Authorization: `JWT ${localStorage.getItem("tk")}` } }
 					)
 					.then(() => {
-						setOpenAlert(true);
-						setSeverityAlert("success");
-						setAlertHelperText("Tipo cadastrado!");
+						onSuccess();
 					})
 					.catch(() => {
 						connectionError();

--- a/sysarq/src/pages/Fields/Create/CreatePublicWorker.js
+++ b/sysarq/src/pages/Fields/Create/CreatePublicWorker.js
@@ -49,6 +49,14 @@ export default function CreatePublicWorker() {
 		);
 	};
 
+	const onSuccess = () => {
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText("Servidor cadastrado!");
+		setName("");
+		setCpf("");
+	}
+
 	const onClick = () => {
 		if (workerName === "") {
 			setNameError(true);
@@ -78,9 +86,8 @@ export default function CreatePublicWorker() {
 						{ headers: { Authorization: `JWT ${localStorage.getItem("tk")}` } }
 					)
 					.then(() => {
-						setOpenAlert(true);
-						setSeverityAlert("success");
-						setAlertHelperText("Servidor cadastrado!");
+
+						onSuccess();
 					})
 					.catch(() => {
 						connectionError();

--- a/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
+++ b/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
@@ -66,6 +66,18 @@ export default function CreateShelfOrRack({ urlType }) {
 		setType(event.target.value);
 	};
 
+	const onSuccess = () => {
+		
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText(`${type} cadastrada!`);
+		// For some reason, the value of the labels doesn't change
+		// when using setNumberE() and setNumberP(), but goes to none
+		// when the type changes
+		setType("Prateleira");
+		setType("Estante");
+	}
+
 	const onClick = () => {
 		if (numberE === "" && type === "Estante") {
 			setShelfNumberError(true);
@@ -97,9 +109,7 @@ export default function CreateShelfOrRack({ urlType }) {
 							}
 						)
 						.then(() => {
-							setOpenAlert(true);
-							setSeverityAlert("success");
-							setAlertHelperText("Estante cadastrada!");
+							onSuccess();
 						})
 						.catch(() => {
 							connectionError();
@@ -116,9 +126,7 @@ export default function CreateShelfOrRack({ urlType }) {
 							}
 						)
 						.then(() => {
-							setOpenAlert(true);
-							setSeverityAlert("success");
-							setAlertHelperText("Prateleira cadastrada!");
+							onSuccess();
 						})
 						.catch(() => {
 							connectionError();

--- a/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
+++ b/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
@@ -64,6 +64,8 @@ export default function CreateShelfOrRack({ urlType }) {
 
 	const handleValueChange = (event) => {
 		setType(event.target.value);
+		setNumberE('');
+		setNumberP('');
 	};
 
 	const onSuccess = () => {
@@ -71,13 +73,8 @@ export default function CreateShelfOrRack({ urlType }) {
 		setOpenAlert(true);
 		setSeverityAlert("success");
 		setAlertHelperText(`${type} cadastrada!`);
-		// For some reason, the value of the labels doesn't change
-		// when using setNumberE() and setNumberP(), but goes to none
-		// when the type changes
-		setType("Prateleira");
-		setType("Estante");
-		setNumberE("");
-		setNumberP("");
+		setNumberE('');
+		setNumberP('');
 	}
 
 	const onClick = () => {
@@ -191,6 +188,7 @@ export default function CreateShelfOrRack({ urlType }) {
 										id="Estante"
 										label="Número da estante*"
 										type="number"
+										value={numberE}
 										onChange={(event) => {
 											setNumberE(event.target.value);
 											setShelfNumberError(false);
@@ -208,6 +206,7 @@ export default function CreateShelfOrRack({ urlType }) {
 										id="Prateleira"
 										label="Número da prateleira*"
 										type="number"
+										value={numberP}
 										onChange={(event) => {
 											setNumberP(event.target.value);
 											setRackNumberError(false);

--- a/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
+++ b/sysarq/src/pages/Fields/Create/CreateShelfOrRack.js
@@ -76,6 +76,8 @@ export default function CreateShelfOrRack({ urlType }) {
 		// when the type changes
 		setType("Prateleira");
 		setType("Estante");
+		setNumberE("");
+		setNumberP("");
 	}
 
 	const onClick = () => {

--- a/sysarq/src/pages/Fields/Create/CreateUnity.js
+++ b/sysarq/src/pages/Fields/Create/CreateUnity.js
@@ -49,6 +49,19 @@ export default function CreateUnity() {
 		setSeverityAlert("error");
 	};
 
+	const onSuccess = () => {
+		setOpenAlert(true);
+		setSeverityAlert("success");
+		setAlertHelperText("Unidade cadastrada!");
+		setUnityName("");
+		setUnityAbbreviation("");
+		setAdiministrativeBond("");
+		setBondAbbreviation("");
+		setCounty("");
+		setTelephoneNumber("");
+		setNote("");
+	}
+
 	const onClick = () => {
 		if (unityName === "") {
 			setunityNameError(true);
@@ -77,9 +90,7 @@ export default function CreateUnity() {
 						{ headers: { Authorization: `JWT ${localStorage.getItem("tk")}` } }
 					)
 					.then(() => {
-						setOpenAlert(true);
-						setSeverityAlert("success");
-						setAlertHelperText("Unidade cadastrada!");
+						onSuccess();
 					})
 					.catch(() => {
 						connectionError();


### PR DESCRIPTION
Função `onSuccess` implementada nos campos obrigatórios para limpar os dados

Co-authored by: Cleber cleberobb@hotmail.com

## Descrição 

- Criação da função para limpar os campos e mostrar o pop-up com a mensagem de sucesso

## Issue Correspondente

[Issue 15](https://github.com/fga-eps-mds/2021-2-sysarq-doc/issues/15)

## Checklist 

* [ ] Nome do pull request significativo e representa o que está sendo submetido.
* [ ] Passou nos testes de integração
* [ ] Branch de acordo com a política de gerenciamento e configuração
* [ ] Critérios de aceitação cumpridos
* [ ] Caso necessário, realizou teste correspondente às funcionalidades implementadas.
* [ ] Revisor marcado