### PR TITLE
49- Direcionar direto para o forms de cadastro

### DIFF
--- a/sysarq/src/pages/Documents/index.js
+++ b/sysarq/src/pages/Documents/index.js
@@ -6,25 +6,25 @@ const Documents = () => (
 		<MenuCard
 			icon="administrative-process-icon"
 			title="Processo Administrativo"
-			url="/documents/administrative-process"
+			url="/documents/administrative-process/create"
 			lg={3}
 		/>
 		<MenuCard
 			icon="frequency-relation-icon"
 			title="Relação de Frequências"
-			url="/documents/frequency-relation"
+			url="/documents/frequency-relation/create"
 			lg={3}
 		/>
 		<MenuCard
 			icon="frequency-sheet-icon"
 			title="Folha de Frequências"
-			url="/documents/frequency-sheet"
+			url="/documents/frequency-sheet/create"
 			lg={3}
 		/>
 		<MenuCard
 			icon="box-archiving-icon"
 			title="Arquivamento de Caixas"
-			url="/documents/box-archiving"
+			url="/documents/box-archiving/create"
 			lg={3}
 		/>
 	</CardContainer>

--- a/sysarq/src/pages/Fields/index.js
+++ b/sysarq/src/pages/Fields/index.js
@@ -8,32 +8,37 @@ const Fields = () => (
 		<MenuCard
 			icon="subject-icon"
 			title="Assunto do Documento"
-			url="/fields/document-subject"
+			url="/fields/document-subject/create"
 			lg={4}
 		/>
-		<MenuCard icon="unit-icon" title="Unidade" url="/fields/unity" lg={4} />
+		<MenuCard 
+			icon="unit-icon" 
+			title="Unidade" 
+			url="/fields/unity/create" 
+			lg={4} 
+		/>
 		<MenuCard
 			icon="abbreviation-icon"
 			title="Caixa"
-			url="/fields/box-abbreviation"
+			url="/fields/box-abbreviation/create"
 			lg={4}
 		/>
 		<MenuCard
 			icon="document-type-icon"
 			title="Tipo de Documento"
-			url="/fields/document-type"
+			url="/fields/document-type/create"
 			lg={4}
 		/>
 		<MenuCard
 			icon="shelf-rack-icon"
 			title="Estante e Prateleira"
-			url="/fields/shelf"
+			url="/fields/shelf/create"
 			lg={4}
 		/>
 		<MenuCard
 			icon="public-worker-icon"
 			title="Servidor"
-			url="/fields/public-worker"
+			url="/fields/public-worker/create"
 			lg={4}
 		/>
 	</CardContainer>


### PR DESCRIPTION
Redirecionamento dos documentos e dos campos obrigatorios para a página de criação

Co-authored by: Gabriel alexgabriel3357@gmail.com

## Descrição 

Agora, ao clicar nas abas de criação de documentos e campos obrigatórios, o usuário é redirecionado para a página de criação do documento/campo obrigatório em questão. Antes, o usuário era redirecionado para a página de listagem, que possui um botão para adicionar.

## Issue Correspondente

[Issue 49](https://github.com/fga-eps-mds/2021-2-SysArq-Doc/issues/49)

## Checklist 

* [x] Nome do pull request significativo e representa o que está sendo submetido.
* [x] Passou nos testes de integração
* [x] Branch de acordo com a política de gerenciamento e configuração
* [x] Critérios de aceitação cumpridos
* [ ] Caso necessário, realizou teste correspondente às funcionalidades implementadas.
* [x] Revisor marcado