### PR TITLE
Informar quando temporalidade de documento é atingida

### DIFF
--- a/sysarq/src/pages/components/DataTable/index.js
+++ b/sysarq/src/pages/components/DataTable/index.js
@@ -304,16 +304,16 @@ const DataTable = ({ url, title }) => {
 			}
 			return obj;
 		}
+		if (id === "info") {
+			if (row[id].indexOf("temporality hit") > -1) {
+				return <WarningIcon text="O documento atingiu sua temporalidade"/>;
+			}
+			return " ";
+		}	
 
 		if (typeof row[id] === "undefined" || row[id] === null || row[id] === "")
 			return "-";
 
-		if (id === "info") {
-			if (row[id].indexOf("temporality hit") > -1) {
-				return <WarningIcon text="- A temporalidade desse documento já foi atingida"/>;
-			}
-			return " ";
-		}	
 
 		return row[id];
 	};

--- a/sysarq/src/pages/components/DataTable/index.js
+++ b/sysarq/src/pages/components/DataTable/index.js
@@ -144,14 +144,16 @@ const DataTable = ({ url, title }) => {
         let d = date.slice();
         const datePropertyYear = date.slice(0, 4);
 		d = d.replace(datePropertyYear, year.toString());
+		console.log(d);
 		return new Date(d);
     }
 
     const handleTemporalityStatus = (data) => {
+		console.log(data[0]);
         const datePropertyOptions = {
-            'administrative-process/': 'notice_date',
+            'administrative-process/': 'archiving_date',
             'frequency-sheet/': 'reference_period',
-            'frequency-relation/': 'refeence_period'
+            'frequency-relation/': 'received_date'
         }
 
         const dateProperty = datePropertyOptions[url];

--- a/sysarq/src/pages/components/DataTable/index.js
+++ b/sysarq/src/pages/components/DataTable/index.js
@@ -140,6 +140,32 @@ const DataTable = ({ url, title }) => {
 		);
 	};
 
+	const calcTemporalityDate = (year, date) => {
+        let d = date.slice();
+        const datePropertyYear = date.slice(0, 4);
+		d = d.replace(datePropertyYear, year.toString());
+		return new Date(d);
+    }
+
+    const handleTemporalityStatus = (data) => {
+        const datePropertyOptions = {
+            'administrative-process/': 'notice_date',
+            'frequency-sheet/': 'reference_period',
+            'frequency-relation/': 'refeence_period'
+        }
+
+        const dateProperty = datePropertyOptions[url];
+        const today = new Date();
+
+        return data.map((item) => {
+			console.log(item.temporality_date)
+            const document = {...item};
+            const temporalityDate = calcTemporalityDate(document.temporality_date, document[dateProperty])
+			document.info = temporalityDate <= today ? 'temporality hit' : '';
+            return document;
+        })
+    }
+
 	useEffect(() => {
 		if (updateTable) {
 			setHeadCells(tableHeadCells(url));
@@ -189,20 +215,28 @@ const DataTable = ({ url, title }) => {
 								setRows(listTable);
 							} else {
 								let data = [ ...response.data ]
-								// if (url !== 'box-archiving/') {
-								// 	data = handleTemporalityStatus(data);
-								// }
-								data =  data.map((item, index) => {
-									const newItem = { ...item }
-									newItem.info = index % 3 === 0 ? "temporality hit" : ""
-									return newItem;
-								})
+                                switch(url) {
+									case 'administrative-process/':
+									case 'frequency-sheet/':
+									case 'frequency-relation/':
+										console.log("a");
+										data = handleTemporalityStatus(data);
+										break;
+									default:
+										break;
+                                }
+								// data =  data.map((item, index) => {
+								// 	const newItem = { ...item }
+								// 	newItem.info = index % 3 === 0 ? "temporality hit" : ""
+								// 	return newItem;
+								// })
 								setRows(data);
 							}
 
 							setUpdateTable(false);
 						})
-						.catch(() => {
+						.catch((err) => {
+							console.log(err);
 							setOpenAlert(true);
 							setSeverityAlert("error");
 

--- a/sysarq/src/pages/components/DataTable/index.js
+++ b/sysarq/src/pages/components/DataTable/index.js
@@ -19,7 +19,6 @@ import {
 	TablePagination,
 } from "@material-ui/core";
 
-
 import MuiLink from "@material-ui/core/Link";
 
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -141,32 +140,35 @@ const DataTable = ({ url, title }) => {
 	};
 
 	const calcTemporalityDate = (year, date) => {
-        let d = date.slice();
-        const datePropertyYear = date.slice(0, 4);
+		let d = date.slice();
+		const datePropertyYear = date.slice(0, 4);
 		d = d.replace(datePropertyYear, year.toString());
 		console.log(d);
 		return new Date(d);
-    }
+	};
 
-    const handleTemporalityStatus = (data) => {
+	const handleTemporalityStatus = (data) => {
 		console.log(data[0]);
-        const datePropertyOptions = {
-            'administrative-process/': 'archiving_date',
-            'frequency-sheet/': 'reference_period',
-            'frequency-relation/': 'received_date'
-        }
+		const datePropertyOptions = {
+			"administrative-process/": "archiving_date",
+			"frequency-sheet/": "reference_period",
+			"frequency-relation/": "received_date",
+		};
 
-        const dateProperty = datePropertyOptions[url];
-        const today = new Date();
+		const dateProperty = datePropertyOptions[url];
+		const today = new Date();
 
-        return data.map((item) => {
-			console.log(item.temporality_date)
-            const document = {...item};
-            const temporalityDate = calcTemporalityDate(document.temporality_date, document[dateProperty])
-			document.info = temporalityDate <= today ? 'temporality hit' : '';
-            return document;
-        })
-    }
+		return data.map((item) => {
+			console.log(item.temporality_date);
+			const document = { ...item };
+			const temporalityDate = calcTemporalityDate(
+				document.temporality_date,
+				document[dateProperty]
+			);
+			document.info = temporalityDate <= today ? "temporality hit" : "";
+			return document;
+		});
+	};
 
 	useEffect(() => {
 		if (updateTable) {
@@ -216,17 +218,17 @@ const DataTable = ({ url, title }) => {
 
 								setRows(listTable);
 							} else {
-								let data = [ ...response.data ]
-                                switch(url) {
-									case 'administrative-process/':
-									case 'frequency-sheet/':
-									case 'frequency-relation/':
+								let data = [...response.data];
+								switch (url) {
+									case "administrative-process/":
+									case "frequency-sheet/":
+									case "frequency-relation/":
 										console.log("a");
 										data = handleTemporalityStatus(data);
 										break;
 									default:
 										break;
-                                }
+								}
 								// data =  data.map((item, index) => {
 								// 	const newItem = { ...item }
 								// 	newItem.info = index % 3 === 0 ? "temporality hit" : ""
@@ -342,14 +344,13 @@ const DataTable = ({ url, title }) => {
 		}
 		if (id === "info") {
 			if (row[id].indexOf("temporality hit") > -1) {
-				return <WarningIcon text="O documento atingiu sua temporalidade"/>;
+				return <WarningIcon text="O documento atingiu sua temporalidade" />;
 			}
 			return " ";
-		}	
+		}
 
 		if (typeof row[id] === "undefined" || row[id] === null || row[id] === "")
 			return "-";
-
 
 		return row[id];
 	};
@@ -385,7 +386,7 @@ const DataTable = ({ url, title }) => {
 											}
 											padding="normal"
 											sortDirection={orderBy === headCell.id ? order : false}
-										>	
+										>
 											<TableSortLabel
 												active={orderBy === headCell.id}
 												direction={orderBy === headCell.id ? order : "asc"}
@@ -442,21 +443,21 @@ const DataTable = ({ url, title }) => {
 														{cellContent(row, headCells[headCellIndex].id)}
 													</TableCell>
 
-													{(headCellIndex === headCells.length - 1 &&
-													fieldUrls.indexOf(url) !== -1) && (
-														<TableCell align="right">
-															<IconButton
-																style={{ color: "#fe0000" }}
-																color="inherit"
-																size="small"
-															>
-																<DeleteIcon
-																	data-testid="delete-field"
-																	onClick={() => deleteRow(row)}
-																/>
-															</IconButton>
-														</TableCell>
-													)}
+													{headCellIndex === headCells.length - 1 &&
+														fieldUrls.indexOf(url) !== -1 && (
+															<TableCell align="right">
+																<IconButton
+																	style={{ color: "#fe0000" }}
+																	color="inherit"
+																	size="small"
+																>
+																	<DeleteIcon
+																		data-testid="delete-field"
+																		onClick={() => deleteRow(row)}
+																	/>
+																</IconButton>
+															</TableCell>
+														)}
 												</>
 											)
 										)}
@@ -484,9 +485,18 @@ const DataTable = ({ url, title }) => {
 					<Typography style={{ marginBottom: "1%" }}>
 						<Link
 							className={classes.link}
-							href={url === "shelf/" || "/fields/rack" || "/fields/shelf" || "/fields/file-location"}
+							href={
+								url === "shelf/" ||
+								"/fields/rack" ||
+								"/fields/shelf" ||
+								"/fields/file-location"
+							}
 						>
-							Ver {url === "shelf/" || "Prateleiras" || "Estantes" || "Localidades dos Arquivos"}
+							Ver{" "}
+							{url === "shelf/" ||
+								"Prateleiras" ||
+								"Estantes" ||
+								"Localidades dos Arquivos"}
 						</Link>
 					</Typography>
 				) : (

--- a/sysarq/src/pages/components/DataTable/index.js
+++ b/sysarq/src/pages/components/DataTable/index.js
@@ -19,6 +19,7 @@ import {
 	TablePagination,
 } from "@material-ui/core";
 
+
 import MuiLink from "@material-ui/core/Link";
 
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -30,6 +31,7 @@ import { axiosProfile, axiosArchives } from "../../../Api";
 import { axiosProfileError } from "../../../support";
 
 import PopUpAlert from "../PopUpAlert";
+import WarningIcon from "../WarningIcon";
 
 const useStyles = makeStyles((theme) => ({
 	paper: {
@@ -186,7 +188,16 @@ const DataTable = ({ url, title }) => {
 
 								setRows(listTable);
 							} else {
-								setRows(response.data);
+								let data = [ ...response.data ]
+								// if (url !== 'box-archiving/') {
+								// 	data = handleTemporalityStatus(data);
+								// }
+								data =  data.map((item, index) => {
+									const newItem = { ...item }
+									newItem.info = index % 3 === 0 ? "temporality hit" : ""
+									return newItem;
+								})
+								setRows(data);
 							}
 
 							setUpdateTable(false);
@@ -297,6 +308,13 @@ const DataTable = ({ url, title }) => {
 		if (typeof row[id] === "undefined" || row[id] === null || row[id] === "")
 			return "-";
 
+		if (id === "info") {
+			if (row[id].indexOf("temporality hit") > -1) {
+				return <WarningIcon text="- A temporalidade desse documento já foi atingida"/>;
+			}
+			return " ";
+		}	
+
 		return row[id];
 	};
 
@@ -331,20 +349,20 @@ const DataTable = ({ url, title }) => {
 											}
 											padding="normal"
 											sortDirection={orderBy === headCell.id ? order : false}
-										>
+										>	
 											<TableSortLabel
 												active={orderBy === headCell.id}
 												direction={orderBy === headCell.id ? order : "asc"}
 												onClick={createSortHandler(headCell.id)}
 											>
 												{headCell.label}
-												{orderBy === headCell.id ? (
+												{orderBy === headCell.id && (
 													<span className={classes.visuallyHidden}>
 														{order === "desc"
 															? "sorted descending"
 															: "sorted ascending"}
 													</span>
-												) : null}
+												)}
 											</TableSortLabel>
 										</TableCell>
 
@@ -388,8 +406,8 @@ const DataTable = ({ url, title }) => {
 														{cellContent(row, headCells[headCellIndex].id)}
 													</TableCell>
 
-													{headCellIndex === headCells.length - 1 &&
-													fieldUrls.indexOf(url) !== -1 ? (
+													{(headCellIndex === headCells.length - 1 &&
+													fieldUrls.indexOf(url) !== -1) && (
 														<TableCell align="right">
 															<IconButton
 																style={{ color: "#fe0000" }}
@@ -402,8 +420,6 @@ const DataTable = ({ url, title }) => {
 																/>
 															</IconButton>
 														</TableCell>
-													) : (
-														""
 													)}
 												</>
 											)

--- a/sysarq/src/pages/components/DataTable/tablesHeadCells.js
+++ b/sysarq/src/pages/components/DataTable/tablesHeadCells.js
@@ -177,6 +177,11 @@ const administrativeProcessHeadCells = [
 		numeric: false,
 		label: "Assunto do Documento",
 	},
+	{
+		id: "info",
+		numeric: false,
+		label: "Info"
+	},
 ];
 
 const frequencyRelationHeadCells = [
@@ -194,6 +199,11 @@ const frequencyRelationHeadCells = [
 		id: "document_name_name",
 		numeric: false,
 		label: "Nome do Documento",
+	},
+	{
+		id: "info",
+		numeric: false,
+		label: "Info"
 	},
 ];
 
@@ -217,6 +227,11 @@ const frequencySheetHeadCells = [
 		id: "reference_period",
 		numeric: false,
 		label: "Período de Frequência",
+	},
+	{
+		id: "info",
+		numeric: false,
+		label: "Info"
 	},
 ];
 

--- a/sysarq/src/pages/components/DataTable/tablesHeadCells.js
+++ b/sysarq/src/pages/components/DataTable/tablesHeadCells.js
@@ -180,7 +180,7 @@ const administrativeProcessHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: "Info"
+		label: ""
 	},
 ];
 
@@ -203,7 +203,7 @@ const frequencyRelationHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: "Info"
+		label: ""
 	},
 ];
 
@@ -231,7 +231,7 @@ const frequencySheetHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: "Info"
+		label: ""
 	},
 ];
 

--- a/sysarq/src/pages/components/DataTable/tablesHeadCells.js
+++ b/sysarq/src/pages/components/DataTable/tablesHeadCells.js
@@ -90,7 +90,6 @@ const unityHeadCells = [
 ];
 
 const headCellsBoxAbbreviation = [
-
 	{
 		id: "name",
 		numeric: false,
@@ -102,7 +101,6 @@ const headCellsBoxAbbreviation = [
 		numeric: false,
 		label: "Sigla",
 	},
-
 ];
 
 const documentNameHeadCells = [
@@ -180,7 +178,7 @@ const administrativeProcessHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: ""
+		label: "",
 	},
 ];
 
@@ -203,7 +201,7 @@ const frequencyRelationHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: ""
+		label: "",
 	},
 ];
 
@@ -231,7 +229,7 @@ const frequencySheetHeadCells = [
 	{
 		id: "info",
 		numeric: false,
-		label: ""
+		label: "",
 	},
 ];
 

--- a/sysarq/src/pages/components/WarningIcon/index.js
+++ b/sysarq/src/pages/components/WarningIcon/index.js
@@ -1,60 +1,61 @@
-import { useState } from 'react';
-import ReportProblemOutlinedIcon from '@material-ui/icons/ReportProblemOutlined';
-import { Popover, Typography, makeStyles } from '@material-ui/core';
+import { useState } from "react";
+import ReportProblemOutlinedIcon from "@material-ui/icons/ReportProblemOutlined";
+import { Popover, Typography, makeStyles } from "@material-ui/core";
 import PropTypes from "prop-types";
 
 const useStyles = makeStyles((theme) => ({
-    popover: {
-        pointerEvents: 'none',
-    },
-    popoverContent: {
-        padding: theme.spacing(1),
-    }
-}))
+	popover: {
+		pointerEvents: "none",
+	},
+	popoverContent: {
+		padding: theme.spacing(1),
+	},
+}));
 
-const WarningIcon = ({text}) => {
-    const classes = useStyles();
-    const [ anchorEl, setAnchorEl ] = useState(null);
+const WarningIcon = ({ text }) => {
+	const classes = useStyles();
+	const [anchorEl, setAnchorEl] = useState(null);
 
-    const handlePopoverOpen = (event) => {
-        setAnchorEl(event.currentTarget);
-    };
-    const handlePopoverClose = () => {
-        setAnchorEl(undefined);
-    };
+	const handlePopoverOpen = (event) => {
+		setAnchorEl(event.currentTarget);
+	};
+	const handlePopoverClose = () => {
+		setAnchorEl(undefined);
+	};
 
-    return (
-        <>
-            <ReportProblemOutlinedIcon 
-                aria-owns={anchorEl ? 'warning-popover' : undefined}
-                aria-haspopup="true"
-                color="primary"
-                onMouseEnter={handlePopoverOpen}
-                onMouseLeave={handlePopoverClose}/>
-            <Popover
-                id="warning-popover"
-                className={classes.popover}
-                classes={{
-                    paper: classes.popoverContent
-                }}
-                open={Boolean(anchorEl)}
-                anchorEl={anchorEl}
-                anchorOrigin={{
-                    vertical:"top",
-                    horizontal: "left",
-                }}
-                transformOrigin={{
-                    vertical:"bottom",
-                    horizontal:"right",
-                }}
-                onClose={handlePopoverClose}
-                disableRestoreFocuse
-            >
-                <Typography>{text}</Typography>
-            </Popover>
-        </>
-    );
-}
+	return (
+		<>
+			<ReportProblemOutlinedIcon
+				aria-owns={anchorEl ? "warning-popover" : undefined}
+				aria-haspopup="true"
+				color="primary"
+				onMouseEnter={handlePopoverOpen}
+				onMouseLeave={handlePopoverClose}
+			/>
+			<Popover
+				id="warning-popover"
+				className={classes.popover}
+				classes={{
+					paper: classes.popoverContent,
+				}}
+				open={Boolean(anchorEl)}
+				anchorEl={anchorEl}
+				anchorOrigin={{
+					vertical: "top",
+					horizontal: "left",
+				}}
+				transformOrigin={{
+					vertical: "bottom",
+					horizontal: "right",
+				}}
+				onClose={handlePopoverClose}
+				disableRestoreFocuse
+			>
+				<Typography>{text}</Typography>
+			</Popover>
+		</>
+	);
+};
 
 WarningIcon.propTypes = {
 	text: PropTypes.string.isRequired,

--- a/sysarq/src/pages/components/WarningIcon/index.js
+++ b/sysarq/src/pages/components/WarningIcon/index.js
@@ -9,7 +9,6 @@ const useStyles = makeStyles((theme) => ({
     },
     popoverContent: {
         padding: theme.spacing(1),
-        backgroundColor: '#FAF98B',
     }
 }))
 

--- a/sysarq/src/pages/components/WarningIcon/index.js
+++ b/sysarq/src/pages/components/WarningIcon/index.js
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import ReportProblemOutlinedIcon from '@material-ui/icons/ReportProblemOutlined';
+import { Popover, Typography, makeStyles } from '@material-ui/core';
+import PropTypes from "prop-types";
+
+const useStyles = makeStyles((theme) => ({
+    popover: {
+        pointerEvents: 'none',
+    },
+    popoverContent: {
+        padding: theme.spacing(1),
+        backgroundColor: '#FAF98B',
+    }
+}))
+
+const WarningIcon = ({text}) => {
+    const classes = useStyles();
+    const [ anchorEl, setAnchorEl ] = useState(null);
+
+    const handlePopoverOpen = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handlePopoverClose = () => {
+        setAnchorEl(undefined);
+    };
+
+    return (
+        <>
+            <ReportProblemOutlinedIcon 
+                aria-owns={anchorEl ? 'warning-popover' : undefined}
+                aria-haspopup="true"
+                color="primary"
+                onMouseEnter={handlePopoverOpen}
+                onMouseLeave={handlePopoverClose}/>
+            <Popover
+                id="warning-popover"
+                className={classes.popover}
+                classes={{
+                    paper: classes.popoverContent
+                }}
+                open={Boolean(anchorEl)}
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                    vertical:"top",
+                    horizontal: "left",
+                }}
+                transformOrigin={{
+                    vertical:"bottom",
+                    horizontal:"right",
+                }}
+                onClose={handlePopoverClose}
+                disableRestoreFocuse
+            >
+                <Typography>{text}</Typography>
+            </Popover>
+        </>
+    );
+}
+
+WarningIcon.propTypes = {
+	text: PropTypes.string.isRequired,
+};
+
+export default WarningIcon;


### PR DESCRIPTION
## Descrição 

Adicionar um campo nas tabelas de documentos para mostrar quando um documento atinge sua temporalidade

## Issue Correspondente

[Issue 37](https://github.com/fga-eps-mds/2021-2-SysArq-Doc/issues/37)

## Checklist 

* [ ] Nome do pull request significativo e representa o que está sendo submetido.
* [ ] Passou nos testes de integração
* [ ] Branch de acordo com a política de gerenciamento e configuração
* [ ] Critérios de aceitação cumpridos
* [ ] Caso necessário, realizou teste correspondente às funcionalidades implementadas.
* [ ] Revisor marcado

## Anexos

![image](https://user-images.githubusercontent.com/75345775/163879308-7d33e34d-5afb-4055-9f03-a1dc285d54f4.png)
Exemplo de como o aviso fica

## Comentários adicionais

<!-- Área livre e opcional, para comentar algo que julgue ser necessário, como explicar mais profundamente o que foi implementado, 
compartilhamento de informações, dependências encontradas durante a implementação e etc. -->
